### PR TITLE
Fix README typos and add simple CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate docker compose
+        run: docker compose config
+      - name: Lint init.sh
+        run: bash -n init.sh

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Bộ docker compose này sẽ hoạt động với tất cả thành phần bao gồm:
 - Nginx
-- Fhp-Fpm (wordrepss)
+- PHP-FPM (WordPress)
 - Mariadb
 - Redis
-- SSL cerbot
+- SSL certbot
   
 Để tránh việc vô ý tác  động vào dữ liệu nên  dữ liệu sẽ được lưu trữ và quản lý bởi docker volume và  sẽ phải tạo trước khi khởi động compose này,  để có thể sử dụng stack này cần thực hiện chính xác các  bước sau.
 

--- a/init.sh
+++ b/init.sh
@@ -5,10 +5,10 @@ if ! command -v docker &> /dev/null; then
     exit 1
 fi
 
-# Update package list and install dnsutils and cron
+# Update package list and install dnsutils, git, and cron
 echo "Update and install necessary packages"
 apt-get update > /dev/null
-apt-get install -y dnsutils cron > /dev/null
+apt-get install -y dnsutils git cron > /dev/null
 
 # domain infomation
 while true; do


### PR DESCRIPTION
## Summary
- fix README typos
- install `git` in init script
- add GitHub Actions workflow to lint compose file and init script

## Testing
- `docker compose config` *(fails: `docker: command not found`)*
- `bash -n init.sh`

------
https://chatgpt.com/codex/tasks/task_e_685176095f2c8320afbd6246acbf5430