### PR TITLE
Update MariaDB healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "mysqladmin ping -uroot -p$MARIADB_ROOT_PASSWORD -h localhost"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- update the healthcheck for the MariaDB service to pass root credentials

## Testing
- `pip install pyyaml`
- `python3 - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68519421e8c08320803a04ca211005fb