### PR TITLE
Fix small typo in init script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -135,4 +135,4 @@ echo 'alias wpcli="docker compose run -ti --rm --no-deps --quiet-pull wpcli"' >>
 source ~/.bash_aliases
 echo "I have completed my mission, in the process of erasing myself."
 rm init.sh
-echo "Have a nive day !!!"
+echo "Have a nice day !!!"


### PR DESCRIPTION
## Summary
- correct closing message in `init.sh`

## Testing
- `docker-compose config` *(fails: Couldn't find env file)*
- `bash -n init.sh`

------
https://chatgpt.com/codex/tasks/task_e_685195636eb48320982d61c7edd28fc6