### PR TITLE
Fix typo in NGINX config comment

### DIFF
--- a/conf/nginx/conf.d/example.com.conf
+++ b/conf/nginx/conf.d/example.com.conf
@@ -68,7 +68,7 @@ server {
 	client_max_body_size 50m;
 	client_body_buffer_size 128k;
 
-	# config SLL path
+        # config SSL path
 	http2 on;
 	ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;


### PR DESCRIPTION
## Summary
- fix small typo in `example.com.conf`

## Testing
- `docker-compose -f docker-compose.yml config` *(fails: couldn't find .env file)*

------
https://chatgpt.com/codex/tasks/task_e_68519b2b9e8c832091cc63e43a5f4506