### PR TITLE
Fix whitespace issues in nginx config

### DIFF
--- a/conf/nginx/conf.d/example.com.conf
+++ b/conf/nginx/conf.d/example.com.conf
@@ -63,7 +63,7 @@ server {
 	# Slowloris attack
 	client_body_timeout 5s;
 	client_header_timeout 5s;
-        
+
 	# Upload limit
 	client_max_body_size 50m;
 	client_body_buffer_size 128k;
@@ -74,7 +74,7 @@ server {
         ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
         ssl_trusted_certificate /etc/letsencrypt/live/example.com/chain.pem;
 	include conf.d/addoption/options-ssl.conf;
-        
+
 	# Add Permalink Support to NGINX
         location / {
                 try_files $uri $uri/ /index.php$is_args$args;
@@ -118,7 +118,7 @@ server {
 		fastcgi_cache_valid 1s;
 		fastcgi_cache_use_stale error timeout updating invalid_header http_500 http_503;
 		fastcgi_cache_background_update on;
-		
+
 		# Don't cache when $skip_cache is true
 		fastcgi_cache_bypass $skip_cache;
         	fastcgi_no_cache $skip_cache;


### PR DESCRIPTION
## Summary
- remove trailing whitespace from `example.com.conf`
- keep single newline at EOF

## Testing
- `grep -nP "\s+$" -n conf/nginx/conf.d/example.com.conf`

------
https://chatgpt.com/codex/tasks/task_e_68519ac383d0832083550befdbdc2a9d