### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Exclude log files and logs directory
+logs/
+*.log
+
+# Exclude optional modsecurity ruleset
+conf/nginx/modsec/coreruleset/
+
+# Ignore version control and CI files
+.git
+.github
+.gitignore
+
+# Environment examples or local environment files
+.env
+.env.example
+


### PR DESCRIPTION
## Summary
- keep Docker build context small
- ignore logs, modsec coreruleset, and development files

## Testing
- `docker compose config` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519b08f05c8320b91326d109bc63dd